### PR TITLE
Add backticks to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ To use:
 - `:colo nofrils-acme **NEW**`
 
 To customize:
-- `:let g:nofrils\_strbackgrounds=1` to turn highlighted string backgrounds, for languages where strings are a major part of them
-- `:let g:nofrils\_heavycomments=1` to turn on high contrast comments rather than the default faded style, for projects where the comments are not deceit and lies
-- `:let g:nofrils\_heavylinenumbers=1` to turn on brighter line numbers, for people who use relative line numbers to hop around
+- `:let g:nofrils_strbackgrounds=1` to turn highlighted string backgrounds, for languages where strings are a major part of them
+- `:let g:nofrils_heavycomments=1` to turn on high contrast comments rather than the default faded style, for projects where the comments are not deceit and lies
+- `:let g:nofrils_heavylinenumbers=1` to turn on brighter line numbers, for people who use relative line numbers to hop around
 
 Commands (once theme is loaded):
 - `:NofrilsDark` use dark theme

--- a/README.md
+++ b/README.md
@@ -1,50 +1,50 @@
 This is an extremely minimalist vim colorscheme (almost no syntax highlighting).
 
 To use:
-- :colo nofrils-dark
-- :colo nofrils-light
-- :colo nofrils-sepia
-- :colo nofrils-acme **NEW**
+- `:colo nofrils-dark`
+- `:colo nofrils-light`
+- `:colo nofrils-sepia`
+- `:colo nofrils-acme **NEW**`
 
 To customize:
-- :let g:nofrils\_strbackgrounds=1 to turn highlighted string backgrounds, for languages where strings are a major part of them
-- :let g:nofrils\_heavycomments=1 to turn on high contrast comments rather than the default faded style, for projects where the comments are not deceit and lies
-- :let g:nofrils\_heavylinenumbers=1 to turn on brighter line numbers, for people who use relative line numbers to hop around
+- `:let g:nofrils\_strbackgrounds=1` to turn highlighted string backgrounds, for languages where strings are a major part of them
+- `:let g:nofrils\_heavycomments=1` to turn on high contrast comments rather than the default faded style, for projects where the comments are not deceit and lies
+- `:let g:nofrils\_heavylinenumbers=1` to turn on brighter line numbers, for people who use relative line numbers to hop around
 
 Commands (once theme is loaded):
-- :NofrilsDark use dark theme
-- :NofrilsLight use light theme
-- :NofrilsSepia use sepia theme
-- :NofrilsAcme use acme theme
-- :NofrilsFocusNormal reset back to normal settings
-- :NofrilsFocusCode focus only code, fade everything else
-- :NofrilsFocusComments focus only comments, fade everything else
+- `:NofrilsDark` use dark theme
+- `:NofrilsLight` use light theme
+- `:NofrilsSepia` use sepia theme
+- `:NofrilsAcme` use acme theme
+- `:NofrilsFocusNormal` reset back to normal settings
+- `:NofrilsFocusCode` focus only code, fade everything else
+- `:NofrilsFocusComments` focus only comments, fade everything else
 
 The only highlighted elements are spelling, errors, comments, vim features (diff, etc) and *optionally* string backgrounds
 
 **Click for non-fuzzified versions**
 
-*nofrils-dark*: **let g:nofrils_heavylinenumbers=1**, **:let g:nofrils_strbackgrounds=1** and **:let g:nofrils_heavycomments=1**
+*nofrils-dark*: **`:let g:nofrils_heavylinenumbers=1`**, **`:let g:nofrils_strbackgrounds=1`** and **`:let g:nofrils_heavycomments=1`**
 ![Dark Version](http://i.imgur.com/1lUx2hY.png)
 
 ----
 
-*nofrils-acme*: **let g:nofrils_heavylinenumbers=0**, **:let g:nofrils_strbackgrounds=0** and **:let g:nofrils_heavycomments=0**
+*nofrils-acme*: **`:let g:nofrils_heavylinenumbers=0`**, **`:let g:nofrils_strbackgrounds=0`** and **`:let g:nofrils_heavycomments=0`**
 ![Acme Version](http://i.imgur.com/yn7OJrY.png)
 
 ----
 
-*nofrils-sepia*: **let g:nofrils_heavylinenumbers=1**, **:let g:nofrils_strbackgrounds=0** and **:let g:nofrils_heavycomments=1**
+*nofrils-sepia*: **`:let g:nofrils_heavylinenumbers=1`**, **`:let g:nofrils_strbackgrounds=0`** and **`:let g:nofrils_heavycomments=1`**
 ![Sepia Version](http://i.imgur.com/zwW5kir.png)
 
 ----
 
-*nofrils-light*: **let g:nofrils_heavylinenumbers=0**, **:let g:nofrils_strbackgrounds=0** and **:let g:nofrils_heavycomments=1**
+*nofrils-light*: **`:let g:nofrils_heavylinenumbers=0`**, **`:let g:nofrils_strbackgrounds=0`** and **`:let g:nofrils_heavycomments=1`**
 ![Light Version](http://i.imgur.com/XXoxztJ.png)
 
 ----
 
-*nofrils-acme*: **let g:nofrils_heavylinenumbers=0**, **:let g:nofrils_strbackgrounds=0** and **:let g:nofrils_heavycomments=0**
+*nofrils-acme*: **`:let g:nofrils_heavylinenumbers=0`**, **`:let g:nofrils_strbackgrounds=0`** and **`:let g:nofrils_heavycomments=0`**
 ![Diffs Arcme Version](http://i.imgur.com/cLcbq7M.png)
 
 


### PR DESCRIPTION
This PR adds backticks to the README to make copy/pasting the commands delineated by them easier.

It also removes what appear to be extraneous underscores.

---

Unrelated: Thanks for the blog post and theme—they were my introduction to no/low syntax highlighting and I've been using on and off ever since. It's been hugely valuable when reading unfamiliar, undocumented—but known to be working—Python code, specifically.