### PR TITLE
Use `text/template` instead of `html/template`

### DIFF
--- a/generate_colors.go
+++ b/generate_colors.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"html/template"
+	"text/template"
 	"log"
 	"os"
 )


### PR DESCRIPTION
Automatic escaping for an entirely different format seems to invite trouble.