### PR TITLE
Extend diff support

### DIFF
--- a/generate_colors.go
+++ b/generate_colors.go
@@ -113,8 +113,11 @@ func main() {
 			withName("WildMenu", pmenuRow),
 
 			withName("DiffAdd", diffAddRow),
+			withName("DiffAdded", diffAddRow),
 			withName("DiffChange", diffChangeRow),
+			withName("DiffChanged", diffChangeRow),
 			withName("DiffDelete", diffDeleteRow),
+			withName("DiffRemoved", diffDeleteRow),
 			withName("DiffText", diffTextRow),
 
 			withName("SpellBad", spellRow),


### PR DESCRIPTION
The default `diff.vim` syntax uses `DiffAdded`, `DiffChanged` and
`DiffRemoved` for highlighting diffs.

@robertmeta I wasn't sure how to use `generate_colors.go` to generate the appropriate colors for each theme. Looks like only `nofrils-acme` is defined. I'd love some help here if possible. 🙂 
